### PR TITLE
Add a note to prevent surprises

### DIFF
--- a/reveal.md
+++ b/reveal.md
@@ -38,6 +38,8 @@ Here is an example alias you can put into your user `deps.edn`:
          :exec-fn repl}
 ```
 
+(Note: requires `clj > 1.10.1.672`, see https://insideclojure.org/2020/09/04/clj-exec/)
+
 # Features
 
 ## `tap>` support


### PR DESCRIPTION
I'd recommend adding this (or something like this) to prevent surprises. It didn't take long to find the issue (clj was erroring at me saying `:exec-fn` wasn't recognized), but it would be a nice note, especially considering the fact that I doubt most people keep `clj` up to date.